### PR TITLE
Start DaprPlacementContainer automatically when DaprContainer is started

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,12 @@
             <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 	<profiles>
         <profile>

--- a/src/test/java/io/diagrid/dapr/DaprContainerTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprContainerTest.java
@@ -2,6 +2,7 @@ package io.diagrid.dapr;
 
 import io.dapr.client.domain.State;
 
+import io.restassured.RestAssured;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -16,13 +17,14 @@ import io.dapr.client.domain.Metadata;
 import static java.util.Collections.singletonMap;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertTrue;
 
 public class DaprContainerTest {
 
-    @ClassRule()
+    @ClassRule
     public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8081)); 
 
-    @ClassRule()
+    @ClassRule
     public static DaprContainer daprContainer = new DaprContainer("daprio/daprd")
                                                         .withAppName("dapr-app")
                                                         .withAppPort(8081)
@@ -70,6 +72,17 @@ public class DaprContainerTest {
 
         }
 
+    }
+
+    @Test
+    public void testPlacement() throws Exception {
+        RestAssured.baseURI = "http://" + daprContainer.getHost() + ":" + daprContainer.getMappedPort(3500);
+        boolean isPlacementConnected = RestAssured.given()
+                .get("/v1.0/metadata")
+                .jsonPath()
+                .getString("actorRuntime.placement")
+                .contentEquals("placement: connected");
+        assertTrue(isPlacementConnected);
     }
 
     @Test


### PR DESCRIPTION
Currently, DaprPlacementContainer and DaprContainer should be started manually. This commit adds DaprPlacementContainer as a dependency when DaprContainer is started.
