### PR TITLE
Upgrade checkstyle to 10.17.0

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -253,7 +253,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowedAnnotations" value="Override, Test"/>
     </module>
     <module name="MissingJavadocMethod">

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
@@ -118,7 +118,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.37</version>
+                        <version>10.17.0</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/src/test/java/io/diagrid/dapr/DaprComponentTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprComponentTest.java
@@ -97,7 +97,8 @@ public class DaprComponentTest {
     Assert.assertEquals(false, kvstore.getMetadata().isEmpty());
 
     String componentYaml = dapr.componentToYaml(kvstore);
-    String expectedComponentYaml = "metadata:\n" + //
+    String expectedComponentYaml = "metadata:\n"
+        + //
         "  name: statestore\n"
         + //
         "apiVersion: dapr.io/v1alpha1\n"


### PR DESCRIPTION
This is a tiny PR that fixes `checkstyle.xml` so it is compatible with Checkstyle 10.17.0 and it can be imported into IntelliJ so it can be used for Java code style.