### PR TITLE
fix: class cast exception, map to list

### DIFF
--- a/src/main/java/io/diagrid/dapr/DaprContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprContainer.java
@@ -25,15 +25,7 @@ import org.yaml.snakeyaml.representer.Representer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 public class DaprContainer extends GenericContainer<DaprContainer> {
 
@@ -259,9 +251,13 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
       Map<String, Object> spec = (Map<String, Object>) component.get("spec");
       String version = (String) spec.get("version");
       List<Map<String, Object>> specMetadata =
-          (List<Map<String, Object>>) spec.getOrDefault("metadata", Collections.emptyMap());
+          (List<Map<String, Object>>) spec.getOrDefault("metadata", Arrays.asList(Collections.emptyMap()));
 
       ArrayList<MetadataEntry> metadataEntries = new ArrayList<>();
+
+      if (specMetadata == null) {
+        return withComponent(name, type, version, metadataEntries);
+      }
 
       for (Map<String, Object> specMetadataItem : specMetadata) {
         for (Map.Entry<String, Object> metadataItem : specMetadataItem.entrySet()) {

--- a/src/main/java/io/diagrid/dapr/DaprContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprContainer.java
@@ -251,7 +251,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
       Map<String, Object> spec = (Map<String, Object>) component.get("spec");
       String version = (String) spec.get("version");
       List<Map<String, Object>> specMetadata =
-          (List<Map<String, Object>>) spec.getOrDefault("metadata", Arrays.asList(Collections.emptyMap()));
+          (List<Map<String, Object>>) spec.getOrDefault("metadata", Collections.emptyList());
 
       ArrayList<MetadataEntry> metadataEntries = new ArrayList<>();
 

--- a/src/test/java/io/diagrid/dapr/DaprComponentTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprComponentTest.java
@@ -141,4 +141,21 @@ public class DaprComponentTest {
 
     Assert.assertEquals(expectedComponentYaml, componentYaml);
   }
+
+  @Test
+  public void withComponentFromPathNoMetadata() {
+    final URL componentYaml = this.getClass().getClassLoader().getResource("components/no-metadata-component.yaml");
+    final Path path = Paths.get(componentYaml.getPath());
+
+    final DaprContainer dapr = new DaprContainer("daprio/daprd")
+          .withAppName("dapr-app")
+          .withAppPort(8081)
+          .withComponent(path)
+          .withAppChannelAddress("host.testcontainers.internal");
+
+    final Set<Component> components = dapr.getComponents();
+    Assert.assertEquals(1, components.size());
+    final Component component = components.iterator().next();
+    Assert.assertEquals(true, component.getMetadata().isEmpty());
+  }
 }

--- a/src/test/resources/components/no-metadata-component.yaml
+++ b/src/test/resources/components/no-metadata-component.yaml
@@ -1,0 +1,7 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: statestore
+spec:
+  type: state.redis
+  version: v1


### PR DESCRIPTION
```
      List<Map<String, Object>> specMetadata =
          (List<Map<String, Object>>) spec.getOrDefault("metadata", Collections.emptyMap());
```

If the desired behaviour is to return an empty collection then returning an empty map is not right here. It should be wrapped in a List or should be an empty list. If spec.metadata is mandatory and shouldn't return an empty collection then it should throw an exception (the right one, not class cast exception).