### PR TITLE
chore: update default Dapr version to 1.17.3

### DIFF
--- a/src/main/java/io/diagrid/dapr/DaprContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprContainer.java
@@ -163,9 +163,10 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
   private String appChannelAddress = "localhost";
   private String placementService = "placement";
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("daprio/daprd");
+  private static final String DEFAULT_DAPR_VERSION = "1.17.2";
   private Yaml yaml;
   private DaprPlacementContainer placementContainer;
-  private String placementDockerImageName = "daprio/placement";
+  private String placementDockerImageName = "daprio/placement:" + DEFAULT_DAPR_VERSION;
   private boolean shouldReusePlacement;
 
   /**

--- a/src/main/java/io/diagrid/dapr/DaprContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprContainer.java
@@ -163,7 +163,7 @@ public class DaprContainer extends GenericContainer<DaprContainer> {
   private String appChannelAddress = "localhost";
   private String placementService = "placement";
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("daprio/daprd");
-  private static final String DEFAULT_DAPR_VERSION = "1.17.2";
+  private static final String DEFAULT_DAPR_VERSION = "1.17.3";
   private Yaml yaml;
   private DaprPlacementContainer placementContainer;
   private String placementDockerImageName = "daprio/placement:" + DEFAULT_DAPR_VERSION;

--- a/src/main/java/io/diagrid/dapr/DaprPlacementContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprPlacementContainer.java
@@ -21,7 +21,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class DaprPlacementContainer extends GenericContainer<DaprPlacementContainer> {
 
-  private static final String DEFAULT_DAPR_VERSION = "1.17.2";
+  private static final String DEFAULT_DAPR_VERSION = "1.17.3";
   private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("daprio/placement:" + DEFAULT_DAPR_VERSION);
   private int placementPort = 50006;
 

--- a/src/main/java/io/diagrid/dapr/DaprPlacementContainer.java
+++ b/src/main/java/io/diagrid/dapr/DaprPlacementContainer.java
@@ -21,7 +21,8 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class DaprPlacementContainer extends GenericContainer<DaprPlacementContainer> {
 
-  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("daprio/placement");
+  private static final String DEFAULT_DAPR_VERSION = "1.17.2";
+  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("daprio/placement:" + DEFAULT_DAPR_VERSION);
   private int placementPort = 50006;
 
   /**

--- a/src/test/java/io/diagrid/dapr/DaprComponentTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprComponentTest.java
@@ -28,7 +28,7 @@ public class DaprComponentTest {
 
   @Test
   public void componentStateStoreSerializationTest() {
-    DaprContainer dapr = new DaprContainer("daprio/daprd")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withComponent(new Component(
@@ -60,7 +60,7 @@ public class DaprComponentTest {
 
   @Test
   public void subscriptionSerializationTest() {
-    DaprContainer dapr = new DaprContainer("daprio/daprd")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withSubscription("my-subscription", "pubsub", "topic", "/events")
@@ -85,7 +85,7 @@ public class DaprComponentTest {
     URL stateStoreYaml = this.getClass().getClassLoader().getResource("components/statestore.yaml");
     Path path = Paths.get(stateStoreYaml.getPath());
 
-    DaprContainer dapr = new DaprContainer("daprio/daprd")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withComponent(path)

--- a/src/test/java/io/diagrid/dapr/DaprComponentTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprComponentTest.java
@@ -28,7 +28,7 @@ public class DaprComponentTest {
 
   @Test
   public void componentStateStoreSerializationTest() {
-    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.3")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withComponent(new Component(
@@ -60,7 +60,7 @@ public class DaprComponentTest {
 
   @Test
   public void subscriptionSerializationTest() {
-    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.3")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withSubscription("my-subscription", "pubsub", "topic", "/events")
@@ -85,7 +85,7 @@ public class DaprComponentTest {
     URL stateStoreYaml = this.getClass().getClassLoader().getResource("components/statestore.yaml");
     Path path = Paths.get(stateStoreYaml.getPath());
 
-    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.2")
+    DaprContainer dapr = new DaprContainer("daprio/daprd:1.17.3")
         .withAppName("dapr-app")
         .withAppPort(8081)
         .withComponent(path)

--- a/src/test/java/io/diagrid/dapr/DaprContainerTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprContainerTest.java
@@ -57,7 +57,7 @@ public class DaprContainerTest {
   public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8081));
 
   @ClassRule
-  public static DaprContainer daprContainer = new DaprContainer("daprio/daprd:1.17.2")
+  public static DaprContainer daprContainer = new DaprContainer("daprio/daprd:1.17.3")
       .withAppName("dapr-app")
       .withAppPort(8081)
       .withAppChannelAddress("host.testcontainers.internal");

--- a/src/test/java/io/diagrid/dapr/DaprContainerTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprContainerTest.java
@@ -57,7 +57,7 @@ public class DaprContainerTest {
   public static WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8081));
 
   @ClassRule
-  public static DaprContainer daprContainer = new DaprContainer("daprio/daprd")
+  public static DaprContainer daprContainer = new DaprContainer("daprio/daprd:1.17.2")
       .withAppName("dapr-app")
       .withAppPort(8081)
       .withAppChannelAddress("host.testcontainers.internal");

--- a/src/test/java/io/diagrid/dapr/DaprPlacementContainerTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprPlacementContainerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class DaprPlacementContainerTest {
 
   @ClassRule
-  public static DaprPlacementContainer placement = new DaprPlacementContainer("daprio/placement:1.17.2");
+  public static DaprPlacementContainer placement = new DaprPlacementContainer("daprio/placement:1.17.3");
 
   @Test
   public void testDaprPlacementContainerDefaults() {

--- a/src/test/java/io/diagrid/dapr/DaprPlacementContainerTest.java
+++ b/src/test/java/io/diagrid/dapr/DaprPlacementContainerTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 public class DaprPlacementContainerTest {
 
   @ClassRule
-  public static DaprPlacementContainer placement = new DaprPlacementContainer("daprio/placement");
+  public static DaprPlacementContainer placement = new DaprPlacementContainer("daprio/placement:1.17.2");
 
   @Test
   public void testDaprPlacementContainerDefaults() {


### PR DESCRIPTION
Updates default Dapr version to 1.17.3. Part of Dapr v1.17 post-release checklist (dapr/dapr#9281).

## Changes

- Updated `DEFAULT_DAPR_VERSION` constant to `1.17.3` in `DaprContainer` and `DaprPlacementContainer`
- Updated default placement image reference from `daprio/placement` to `daprio/placement:1.17.3`
- Updated test files to use versioned image tags (`daprio/daprd:1.17.3`, `daprio/placement:1.17.3`)